### PR TITLE
Improve quote escaping in streaming json

### DIFF
--- a/dist/commonjs/hansken-js.js
+++ b/dist/commonjs/hansken-js.js
@@ -665,36 +665,25 @@ var _tryObjectParse = {
     }
 
     var start = 0;
-    var depth = 1;
-    var inEscape = false;
-    var inQuote = false;
+    var inObject = false;
 
-    for (var i = 1; i < buffer.length; i++) {
-      var character = buffer[i];
+    for (var i = 0; i < buffer.length; i++) {
+      var character = buffer.charAt(i);
 
-      if (character === '\\') {
-        inEscape = !inEscape;
-      } else if (!inEscape) {
-        if (character === '"') {
-          inQuote = !inQuote;
-        } else if (!inQuote) {
-          if (character === '{') {
-            if (depth === 0) {
-              start = i;
-            }
-
-            depth++;
-          } else if (character === '}') {
-            depth--;
-
-            if (depth === 0) {
-              callback(JSON.parse(buffer.substring(start, i + 1)));
-              start = i + 1;
-            }
-          }
-        }
-      } else {
-        inEscape = false;
+      if (!inObject && character === '{') {
+        // This is the first encounter of an JSON object
+        inObject = true;
+        start = i;
+      } else if (inObject && character === '}') {
+        // Whenever we come across an JSON object end, try to parse the part that we read
+        // The JSON.parse will throw an exception when the token is not complete (missing })
+        // and we'll try to parse the next time
+        try {
+          var trace = JSON.parse(buffer.substring(start, i + 1));
+          start = i + 1;
+          inObject = false;
+          callback(trace);
+        } catch (_unused) {}
       }
     }
 

--- a/src/modules/projectSearchContext.js
+++ b/src/modules/projectSearchContext.js
@@ -19,37 +19,27 @@ class ProjectSearchContext {
         }
 
         let start = 0;
-        let depth = 1;
-        let inEscape = false;
-        let inQuote = false;
-        for (let i = 1; i < buffer.length; i++) {
+        let inObject = false;
+
+        for (let i = 0; i < buffer.length; i++) {
             const character = buffer.charAt(i);
 
-            if (character === '\\' && inQuote) {
-                inEscape = !inEscape;
-            } else if (!inEscape) {
-                if (character === '"') {
-                    if ((i >= 2 && buffer.charAt(i -1) === '\\' && buffer.charAt(i - 2) === '\\') ||
-                        (i >= 1 && buffer.charAt(i - 1) !== '\\') || i == 0) {
-                        inQuote = !inQuote;
-                    }
-                } else if (!inQuote) {
-                    if (character === '{') {
-                        if (depth === 0) {
-                            start = i;
-                        }
-                        depth++;
-                    }
-                    else if (character === '}') {
-                        depth--;
-                        if (depth === 0) {
-                            callback(JSON.parse(buffer.substring(start, i + 1)));
-                            start = i + 1;
-                        }
-                    }
+            if (!inObject && character === '{') {
+                // This is the first encounter of an JSON object
+                inObject = true;
+                start = i;
+            }
+            else if (inObject && character === '}') {
+                // Whenever we come across an JSON object end, try to parse the part that we read
+                // The JSON.parse will throw an exception when the token is not complete (missing })
+                // and we'll try to parse the next time
+                try {
+                    const trace = JSON.parse(buffer.substring(start, i + 1));
+                    start = i + 1;
+                    inObject = false;
+                    callback(trace);
+                } catch {
                 }
-            } else {
-                inEscape = false;
             }
         }
         return start;

--- a/src/modules/projectSearchContext.js
+++ b/src/modules/projectSearchContext.js
@@ -23,13 +23,16 @@ class ProjectSearchContext {
         let inEscape = false;
         let inQuote = false;
         for (let i = 1; i < buffer.length; i++) {
-            const character = buffer[i];
+            const character = buffer.charAt(i);
 
-            if (character === '\\') {
+            if (character === '\\' && inQuote) {
                 inEscape = !inEscape;
             } else if (!inEscape) {
                 if (character === '"') {
-                    inQuote = !inQuote;
+                    if ((i >= 2 && buffer.charAt(i -1) === '\\' && buffer.charAt(i - 2) === '\\') ||
+                        (i >= 1 && buffer.charAt(i - 1) !== '\\') || i == 0) {
+                        inQuote = !inQuote;
+                    }
                 } else if (!inQuote) {
                     if (character === '{') {
                         if (depth === 0) {


### PR DESCRIPTION
There seemed to be a problem with the streaming json trace results implementation. Escaping of quotes didn't work as expected