### PR TITLE
Add session context for gatekeeper and keystore

### DIFF
--- a/dist/amd/hansken-js.js
+++ b/dist/amd/hansken-js.js
@@ -48,7 +48,7 @@ define('modules/keyManager.js',["exports", "./sessionManager.js"], function (_ex
         return Promise.resolve(_classPrivateFieldGet(_this, _cache)[imageId]);
       }
 
-      return _this.sessionManager.keystore('/session/whoami').then(_sessionManager.SessionManager.json).then(function (whoami) {
+      return _this.sessionContext.whoami().then(function (whoami) {
         return _this.sessionManager.keystore("/entries/".concat(imageId, "/").concat(whoami.uid), {
           method: 'GET'
         });
@@ -78,6 +78,7 @@ define('modules/keyManager.js',["exports", "./sessionManager.js"], function (_ex
     });
 
     this.sessionManager = sessionManager;
+    this.sessionContext = this.sessionManager.session('keystore');
   }
   /**
    * Retrieve a key.
@@ -89,7 +90,74 @@ define('modules/keyManager.js',["exports", "./sessionManager.js"], function (_ex
 
   _exports.KeyManager = KeyManager;
 });
-define('modules/sessionManager.js',["exports", "./keyManager.js"], function (_exports, _keyManager2) {
+define('modules/sessionContext.js',["exports", "./sessionManager.js"], function (_exports, _sessionManager) {
+  "use strict";
+
+  Object.defineProperty(_exports, "__esModule", {
+    value: true
+  });
+  _exports.SessionContext = void 0;
+
+  function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+  function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
+
+  function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+  function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+  function _classPrivateFieldInitSpec(obj, privateMap, value) { _checkPrivateRedeclaration(obj, privateMap); privateMap.set(obj, value); }
+
+  function _checkPrivateRedeclaration(obj, privateCollection) { if (privateCollection.has(obj)) { throw new TypeError("Cannot initialize the same private elements twice on an object"); } }
+
+  function _classPrivateFieldSet(receiver, privateMap, value) { var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "set"); _classApplyDescriptorSet(receiver, descriptor, value); return value; }
+
+  function _classApplyDescriptorSet(receiver, descriptor, value) { if (descriptor.set) { descriptor.set.call(receiver, value); } else { if (!descriptor.writable) { throw new TypeError("attempted to set read only private field"); } descriptor.value = value; } }
+
+  function _classPrivateFieldGet(receiver, privateMap) { var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "get"); return _classApplyDescriptorGet(receiver, descriptor); }
+
+  function _classExtractFieldDescriptor(receiver, privateMap, action) { if (!privateMap.has(receiver)) { throw new TypeError("attempted to " + action + " private field on non-instance"); } return privateMap.get(receiver); }
+
+  function _classApplyDescriptorGet(receiver, descriptor) { if (descriptor.get) { return descriptor.get.call(receiver); } return descriptor.value; }
+
+  var _whoami = /*#__PURE__*/new WeakMap();
+
+  var SessionContext = /*#__PURE__*/_createClass(
+  /**
+   * Create a context for the session of a hansken service.
+   *
+   * @param {SessionManager} sessionManager The session manager, used for connections to the Hansken servers
+   * @param {string} The url of the hansken service
+   */
+  function SessionContext(sessionManager, serviceUrl) {
+    var _this = this;
+
+    _classCallCheck(this, SessionContext);
+
+    _classPrivateFieldInitSpec(this, _whoami, {
+      writable: true,
+      value: void 0
+    });
+
+    _defineProperty(this, "whoami", function () {
+      if (_classPrivateFieldGet(_this, _whoami)) {
+        return Promise.resolve(_classPrivateFieldGet(_this, _whoami));
+      }
+
+      return _this.sessionManager.fetch(_this.serviceUrl, '/session/whoami').then(_sessionManager.SessionManager.json).then(function (whoami) {
+        _classPrivateFieldSet(_this, _whoami, whoami);
+
+        return whoami;
+      });
+    });
+
+    this.sessionManager = sessionManager;
+    this.serviceUrl = serviceUrl;
+  });
+
+  _exports.SessionContext = SessionContext;
+});
+define('modules/sessionManager.js',["exports", "./keyManager.js", "./sessionContext.js"], function (_exports, _keyManager2, _sessionContext2) {
   "use strict";
 
   Object.defineProperty(_exports, "__esModule", {
@@ -125,6 +193,10 @@ define('modules/sessionManager.js',["exports", "./keyManager.js"], function (_ex
 
   var _keyManager = /*#__PURE__*/new WeakMap();
 
+  var _sessions = /*#__PURE__*/new WeakMap();
+
+  var _sessionContext = /*#__PURE__*/new WeakMap();
+
   var SessionManager = /*#__PURE__*/_createClass(
   /**
    * Creates an object that handles the authentication of SAML services.
@@ -142,12 +214,74 @@ define('modules/sessionManager.js',["exports", "./keyManager.js"], function (_ex
       value: void 0
     });
 
+    _classPrivateFieldInitSpec(this, _sessions, {
+      writable: true,
+      value: {}
+    });
+
+    _defineProperty(this, "fetch", function (base, path, req) {
+      // Defaults for Cross Origin Resource Sharing
+      var request = req || {};
+      request.credentials = 'include';
+      request.mode = 'cors'; // TODO accept Request as argument
+
+      return window.fetch("".concat(base).concat(path), request).then(function (response) {
+        var contentType = response.headers.get('Content-Type');
+
+        if (response.status === 401 || response.status === 200 && contentType.indexOf('text/html') === 0) {
+          var clone = response.clone();
+          return response.text().then(function (text) {
+            if (text.indexOf('SAMLRequest') !== -1) {
+              // This is an html form page redirecting you to the default Identity Provider.
+              // Let's orchestrate that request ourself
+              return window.fetch("".concat(base, "/saml/idps"), {
+                credentials: 'include',
+                mode: 'cors'
+              }).then(function (idps) {
+                return idps.json();
+              }).then(function (idps) {
+                if (idps.length === 1) {
+                  // Only one Identity Provider available, redirect to login page with redirectUrl
+                  return _classStaticPrivateMethodGet(SessionManager, SessionManager, _login).call(SessionManager, base, idps[0].entityID);
+                } // Ask the user which Identity Provider should be used
+
+
+                var descriptions = idps.map(function (idp) {
+                  return idp.description || idp.entityID;
+                }).map(function (idp) {
+                  return "\"".concat(idp, "\"");
+                }).join(', ');
+
+                for (var i = 0; i < idps.length; i += 1) {
+                  var idp = idps[i]; // Disable these eslint rules to make sure we can use confirm().
+                  // This is an old browser component, but it is very useful for this case as it is UI Framework independent
+                  // and blocking the thread.
+                  // eslint-disable-next-line no-alert, no-restricted-globals
+
+                  if (confirm("Multiple Identity Providers found: ".concat(descriptions, ". Do you want to login with Identity Provider \"").concat(idp.description ? idp.description : idp.entityID, "\"?"))) {
+                    return _classStaticPrivateMethodGet(SessionManager, SessionManager, _login).call(SessionManager, base, idp.entityID);
+                  }
+                }
+
+                return Promise.reject(new Error('No Identity Provider chosen, unable to retrieve data'));
+              });
+            } // The response body can only be read once, so return the clone
+
+
+            return clone;
+          });
+        }
+
+        return response;
+      });
+    });
+
     _defineProperty(this, "gatekeeper", function (path, request) {
-      return _classStaticPrivateMethodGet(SessionManager, SessionManager, _fetch).call(SessionManager, _this.gatekeeperUrl, path, request);
+      return _this.fetch(_this.gatekeeperUrl, path, request);
     });
 
     _defineProperty(this, "keystore", function (path, request) {
-      return _classStaticPrivateMethodGet(SessionManager, SessionManager, _fetch).call(SessionManager, _this.keystoreUrl, path, request);
+      return _this.fetch(_this.keystoreUrl, path, request);
     });
 
     _defineProperty(this, "keyManager", function () {
@@ -156,6 +290,28 @@ define('modules/sessionManager.js',["exports", "./keyManager.js"], function (_ex
       }
 
       return _classPrivateFieldGet(_this, _keyManager);
+    });
+
+    _classPrivateFieldInitSpec(this, _sessionContext, {
+      writable: true,
+      value: function value(serviceName) {
+        switch (serviceName) {
+          case 'gatekeeper':
+            return new _sessionContext2.SessionContext(_this, _this.gatekeeperUrl);
+
+          case 'keystore':
+            return new _sessionContext2.SessionContext(_this, _this.keystoreUrl);
+        }
+      }
+    });
+
+    _defineProperty(this, "session", function (serviceName) {
+      // Create the session context only once
+      if (!_classPrivateFieldGet(_this, _sessions)[serviceName]) {
+        _classPrivateFieldGet(_this, _sessions)[serviceName] = _classPrivateFieldGet(_this, _sessionContext).call(_this, serviceName);
+      }
+
+      return _classPrivateFieldGet(_this, _sessions)[serviceName];
     });
 
     this.gatekeeperUrl = gatekeeperUrl.replace(/\/+$/, '');
@@ -167,63 +323,6 @@ define('modules/sessionManager.js',["exports", "./keyManager.js"], function (_ex
   function _login(base, entityID) {
     window.location.href = "".concat(base, "/saml/login?idp=").concat(encodeURIComponent(entityID), "&redirectUrl=").concat(encodeURIComponent(window.location.href));
     return Promise.reject(new Error('Redirecting to login page')); // We won't get here
-  }
-
-  function _fetch(base, path, req) {
-    // Defaults for Cross Origin Resource Sharing
-    var request = req || {};
-    request.credentials = 'include';
-    request.mode = 'cors'; // TODO accept Request as argument
-
-    return window.fetch("".concat(base).concat(path), request).then(function (response) {
-      var contentType = response.headers.get('Content-Type');
-
-      if (response.status === 401 || response.status === 200 && contentType.indexOf('text/html') === 0) {
-        var clone = response.clone();
-        return response.text().then(function (text) {
-          if (text.indexOf('SAMLRequest') !== -1) {
-            // This is an html form page redirecting you to the default Identity Provider.
-            // Let's orchestrate that request ourself
-            return window.fetch("".concat(base, "/saml/idps"), {
-              credentials: 'include',
-              mode: 'cors'
-            }).then(function (idps) {
-              return idps.json();
-            }).then(function (idps) {
-              if (idps.length === 1) {
-                // Only one Identity Provider available, redirect to login page with redirectUrl
-                return _classStaticPrivateMethodGet(SessionManager, SessionManager, _login).call(SessionManager, base, idps[0].entityID);
-              } // Ask the user which Identity Provider should be used
-
-
-              var descriptions = idps.map(function (idp) {
-                return idp.description || idp.entityID;
-              }).map(function (idp) {
-                return "\"".concat(idp, "\"");
-              }).join(', ');
-
-              for (var i = 0; i < idps.length; i += 1) {
-                var idp = idps[i]; // Disable these eslint rules to make sure we can use confirm().
-                // This is an old browser component, but it is very useful for this case as it is UI Framework independent
-                // and blocking the thread.
-                // eslint-disable-next-line no-alert, no-restricted-globals
-
-                if (confirm("Multiple Identity Providers found: ".concat(descriptions, ". Do you want to login with Identity Provider \"").concat(idp.description ? idp.description : idp.entityID, "\"?"))) {
-                  return _classStaticPrivateMethodGet(SessionManager, SessionManager, _login).call(SessionManager, base, idp.entityID);
-                }
-              }
-
-              return Promise.reject(new Error('No Identity Provider chosen, unable to retrieve data'));
-            });
-          } // The response body can only be read once, so return the clone
-
-
-          return clone;
-        });
-      }
-
-      return response;
-    });
   }
 
   _defineProperty(SessionManager, "json", function (response) {
@@ -1178,6 +1277,10 @@ define('hansken-js',["exports", "./modules/projectContext.js", "./modules/singef
 
     _defineProperty(this, "keyManager", function () {
       return _this.sessionManager.keyManager();
+    });
+
+    _defineProperty(this, "session", function (serviceName) {
+      return _this.sessionManager.session(serviceName);
     });
 
     _defineProperty(this, "singlefile", function (singlefileId) {

--- a/dist/commonjs/hansken-js.js
+++ b/dist/commonjs/hansken-js.js
@@ -103,6 +103,10 @@ function HanskenClient(gatekeeperUrl, keystoreUrl) {
     return _this.sessionManager.keyManager();
   });
 
+  _defineProperty(this, "session", function (serviceName) {
+    return _this.sessionManager.session(serviceName);
+  });
+
   _defineProperty(this, "singlefile", function (singlefileId) {
     return new _singefileContext.SinglefileContext(_this.sessionManager, singlefileId);
   });
@@ -194,7 +198,7 @@ function HanskenClient(gatekeeperUrl, keystoreUrl) {
 );
 
 exports.HanskenClient = HanskenClient;
-},{"./modules/projectContext.js":4,"./modules/scheduler.js":7,"./modules/sessionManager.js":8,"./modules/singefileContext.js":9,"./modules/traceModelContext.js":11}],2:[function(require,module,exports){
+},{"./modules/projectContext.js":4,"./modules/scheduler.js":7,"./modules/sessionManager.js":9,"./modules/singefileContext.js":10,"./modules/traceModelContext.js":12}],2:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -279,7 +283,7 @@ function AbstractProjectContext(sessionManager, collection, collectionId) {
 );
 
 exports.AbstractProjectContext = AbstractProjectContext;
-},{"./projectImageContext.js":5,"./projectSearchContext.js":6,"./sessionManager.js":8,"./traceContext.js":10}],3:[function(require,module,exports){
+},{"./projectImageContext.js":5,"./projectSearchContext.js":6,"./sessionManager.js":9,"./traceContext.js":11}],3:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -331,7 +335,7 @@ function KeyManager(sessionManager) {
       return Promise.resolve(_classPrivateFieldGet(_this, _cache)[imageId]);
     }
 
-    return _this.sessionManager.keystore('/session/whoami').then(_sessionManager.SessionManager.json).then(function (whoami) {
+    return _this.sessionContext.whoami().then(function (whoami) {
       return _this.sessionManager.keystore("/entries/".concat(imageId, "/").concat(whoami.uid), {
         method: 'GET'
       });
@@ -361,6 +365,7 @@ function KeyManager(sessionManager) {
   });
 
   this.sessionManager = sessionManager;
+  this.sessionContext = this.sessionManager.session('keystore');
 }
 /**
  * Retrieve a key.
@@ -371,7 +376,7 @@ function KeyManager(sessionManager) {
 );
 
 exports.KeyManager = KeyManager;
-},{"./sessionManager.js":8}],4:[function(require,module,exports){
+},{"./sessionManager.js":9}],4:[function(require,module,exports){
 "use strict";
 
 function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
@@ -464,7 +469,7 @@ var ProjectContext = /*#__PURE__*/function (_AbstractProjectConte) {
 }(_abstractProjectContext.AbstractProjectContext);
 
 exports.ProjectContext = ProjectContext;
-},{"./abstractProjectContext.js":2,"./sessionManager.js":8}],5:[function(require,module,exports){
+},{"./abstractProjectContext.js":2,"./sessionManager.js":9}],5:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -521,7 +526,7 @@ function ProjectImageContext(sessionManager, projectId, imageId) {
 );
 
 exports.ProjectImageContext = ProjectImageContext;
-},{"./sessionManager.js":8}],6:[function(require,module,exports){
+},{"./sessionManager.js":9}],6:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -694,7 +699,7 @@ var _tryObjectParse = {
     return start;
   }
 };
-},{"./sessionManager.js":8}],7:[function(require,module,exports){
+},{"./sessionManager.js":9}],7:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -814,7 +819,75 @@ function Scheduler(sessionManager) {
 );
 
 exports.Scheduler = Scheduler;
-},{"./sessionManager.js":8}],8:[function(require,module,exports){
+},{"./sessionManager.js":9}],8:[function(require,module,exports){
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.SessionContext = void 0;
+
+var _sessionManager = require("./sessionManager.js");
+
+function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
+
+function _createClass(Constructor, protoProps, staticProps) { if (protoProps) _defineProperties(Constructor.prototype, protoProps); if (staticProps) _defineProperties(Constructor, staticProps); Object.defineProperty(Constructor, "prototype", { writable: false }); return Constructor; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+function _classPrivateFieldInitSpec(obj, privateMap, value) { _checkPrivateRedeclaration(obj, privateMap); privateMap.set(obj, value); }
+
+function _checkPrivateRedeclaration(obj, privateCollection) { if (privateCollection.has(obj)) { throw new TypeError("Cannot initialize the same private elements twice on an object"); } }
+
+function _classPrivateFieldSet(receiver, privateMap, value) { var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "set"); _classApplyDescriptorSet(receiver, descriptor, value); return value; }
+
+function _classApplyDescriptorSet(receiver, descriptor, value) { if (descriptor.set) { descriptor.set.call(receiver, value); } else { if (!descriptor.writable) { throw new TypeError("attempted to set read only private field"); } descriptor.value = value; } }
+
+function _classPrivateFieldGet(receiver, privateMap) { var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "get"); return _classApplyDescriptorGet(receiver, descriptor); }
+
+function _classExtractFieldDescriptor(receiver, privateMap, action) { if (!privateMap.has(receiver)) { throw new TypeError("attempted to " + action + " private field on non-instance"); } return privateMap.get(receiver); }
+
+function _classApplyDescriptorGet(receiver, descriptor) { if (descriptor.get) { return descriptor.get.call(receiver); } return descriptor.value; }
+
+var _whoami = /*#__PURE__*/new WeakMap();
+
+var SessionContext = /*#__PURE__*/_createClass(
+/**
+ * Create a context for the session of a hansken service.
+ *
+ * @param {SessionManager} sessionManager The session manager, used for connections to the Hansken servers
+ * @param {string} The url of the hansken service
+ */
+function SessionContext(sessionManager, serviceUrl) {
+  var _this = this;
+
+  _classCallCheck(this, SessionContext);
+
+  _classPrivateFieldInitSpec(this, _whoami, {
+    writable: true,
+    value: void 0
+  });
+
+  _defineProperty(this, "whoami", function () {
+    if (_classPrivateFieldGet(_this, _whoami)) {
+      return Promise.resolve(_classPrivateFieldGet(_this, _whoami));
+    }
+
+    return _this.sessionManager.fetch(_this.serviceUrl, '/session/whoami').then(_sessionManager.SessionManager.json).then(function (whoami) {
+      _classPrivateFieldSet(_this, _whoami, whoami);
+
+      return whoami;
+    });
+  });
+
+  this.sessionManager = sessionManager;
+  this.serviceUrl = serviceUrl;
+});
+
+exports.SessionContext = SessionContext;
+},{"./sessionManager.js":9}],9:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -823,6 +896,8 @@ Object.defineProperty(exports, "__esModule", {
 exports.SessionManager = void 0;
 
 var _keyManager2 = require("./keyManager.js");
+
+var _sessionContext2 = require("./sessionContext.js");
 
 function _defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } }
 
@@ -852,6 +927,10 @@ function _classCheckPrivateStaticAccess(receiver, classConstructor) { if (receiv
 
 var _keyManager = /*#__PURE__*/new WeakMap();
 
+var _sessions = /*#__PURE__*/new WeakMap();
+
+var _sessionContext = /*#__PURE__*/new WeakMap();
+
 var SessionManager = /*#__PURE__*/_createClass(
 /**
  * Creates an object that handles the authentication of SAML services.
@@ -869,12 +948,74 @@ function SessionManager(gatekeeperUrl, keystoreUrl) {
     value: void 0
   });
 
+  _classPrivateFieldInitSpec(this, _sessions, {
+    writable: true,
+    value: {}
+  });
+
+  _defineProperty(this, "fetch", function (base, path, req) {
+    // Defaults for Cross Origin Resource Sharing
+    var request = req || {};
+    request.credentials = 'include';
+    request.mode = 'cors'; // TODO accept Request as argument
+
+    return window.fetch("".concat(base).concat(path), request).then(function (response) {
+      var contentType = response.headers.get('Content-Type');
+
+      if (response.status === 401 || response.status === 200 && contentType.indexOf('text/html') === 0) {
+        var clone = response.clone();
+        return response.text().then(function (text) {
+          if (text.indexOf('SAMLRequest') !== -1) {
+            // This is an html form page redirecting you to the default Identity Provider.
+            // Let's orchestrate that request ourself
+            return window.fetch("".concat(base, "/saml/idps"), {
+              credentials: 'include',
+              mode: 'cors'
+            }).then(function (idps) {
+              return idps.json();
+            }).then(function (idps) {
+              if (idps.length === 1) {
+                // Only one Identity Provider available, redirect to login page with redirectUrl
+                return _classStaticPrivateMethodGet(SessionManager, SessionManager, _login).call(SessionManager, base, idps[0].entityID);
+              } // Ask the user which Identity Provider should be used
+
+
+              var descriptions = idps.map(function (idp) {
+                return idp.description || idp.entityID;
+              }).map(function (idp) {
+                return "\"".concat(idp, "\"");
+              }).join(', ');
+
+              for (var i = 0; i < idps.length; i += 1) {
+                var idp = idps[i]; // Disable these eslint rules to make sure we can use confirm().
+                // This is an old browser component, but it is very useful for this case as it is UI Framework independent
+                // and blocking the thread.
+                // eslint-disable-next-line no-alert, no-restricted-globals
+
+                if (confirm("Multiple Identity Providers found: ".concat(descriptions, ". Do you want to login with Identity Provider \"").concat(idp.description ? idp.description : idp.entityID, "\"?"))) {
+                  return _classStaticPrivateMethodGet(SessionManager, SessionManager, _login).call(SessionManager, base, idp.entityID);
+                }
+              }
+
+              return Promise.reject(new Error('No Identity Provider chosen, unable to retrieve data'));
+            });
+          } // The response body can only be read once, so return the clone
+
+
+          return clone;
+        });
+      }
+
+      return response;
+    });
+  });
+
   _defineProperty(this, "gatekeeper", function (path, request) {
-    return _classStaticPrivateMethodGet(SessionManager, SessionManager, _fetch).call(SessionManager, _this.gatekeeperUrl, path, request);
+    return _this.fetch(_this.gatekeeperUrl, path, request);
   });
 
   _defineProperty(this, "keystore", function (path, request) {
-    return _classStaticPrivateMethodGet(SessionManager, SessionManager, _fetch).call(SessionManager, _this.keystoreUrl, path, request);
+    return _this.fetch(_this.keystoreUrl, path, request);
   });
 
   _defineProperty(this, "keyManager", function () {
@@ -883,6 +1024,28 @@ function SessionManager(gatekeeperUrl, keystoreUrl) {
     }
 
     return _classPrivateFieldGet(_this, _keyManager);
+  });
+
+  _classPrivateFieldInitSpec(this, _sessionContext, {
+    writable: true,
+    value: function value(serviceName) {
+      switch (serviceName) {
+        case 'gatekeeper':
+          return new _sessionContext2.SessionContext(_this, _this.gatekeeperUrl);
+
+        case 'keystore':
+          return new _sessionContext2.SessionContext(_this, _this.keystoreUrl);
+      }
+    }
+  });
+
+  _defineProperty(this, "session", function (serviceName) {
+    // Create the session context only once
+    if (!_classPrivateFieldGet(_this, _sessions)[serviceName]) {
+      _classPrivateFieldGet(_this, _sessions)[serviceName] = _classPrivateFieldGet(_this, _sessionContext).call(_this, serviceName);
+    }
+
+    return _classPrivateFieldGet(_this, _sessions)[serviceName];
   });
 
   this.gatekeeperUrl = gatekeeperUrl.replace(/\/+$/, '');
@@ -894,63 +1057,6 @@ exports.SessionManager = SessionManager;
 function _login(base, entityID) {
   window.location.href = "".concat(base, "/saml/login?idp=").concat(encodeURIComponent(entityID), "&redirectUrl=").concat(encodeURIComponent(window.location.href));
   return Promise.reject(new Error('Redirecting to login page')); // We won't get here
-}
-
-function _fetch(base, path, req) {
-  // Defaults for Cross Origin Resource Sharing
-  var request = req || {};
-  request.credentials = 'include';
-  request.mode = 'cors'; // TODO accept Request as argument
-
-  return window.fetch("".concat(base).concat(path), request).then(function (response) {
-    var contentType = response.headers.get('Content-Type');
-
-    if (response.status === 401 || response.status === 200 && contentType.indexOf('text/html') === 0) {
-      var clone = response.clone();
-      return response.text().then(function (text) {
-        if (text.indexOf('SAMLRequest') !== -1) {
-          // This is an html form page redirecting you to the default Identity Provider.
-          // Let's orchestrate that request ourself
-          return window.fetch("".concat(base, "/saml/idps"), {
-            credentials: 'include',
-            mode: 'cors'
-          }).then(function (idps) {
-            return idps.json();
-          }).then(function (idps) {
-            if (idps.length === 1) {
-              // Only one Identity Provider available, redirect to login page with redirectUrl
-              return _classStaticPrivateMethodGet(SessionManager, SessionManager, _login).call(SessionManager, base, idps[0].entityID);
-            } // Ask the user which Identity Provider should be used
-
-
-            var descriptions = idps.map(function (idp) {
-              return idp.description || idp.entityID;
-            }).map(function (idp) {
-              return "\"".concat(idp, "\"");
-            }).join(', ');
-
-            for (var i = 0; i < idps.length; i += 1) {
-              var idp = idps[i]; // Disable these eslint rules to make sure we can use confirm().
-              // This is an old browser component, but it is very useful for this case as it is UI Framework independent
-              // and blocking the thread.
-              // eslint-disable-next-line no-alert, no-restricted-globals
-
-              if (confirm("Multiple Identity Providers found: ".concat(descriptions, ". Do you want to login with Identity Provider \"").concat(idp.description ? idp.description : idp.entityID, "\"?"))) {
-                return _classStaticPrivateMethodGet(SessionManager, SessionManager, _login).call(SessionManager, base, idp.entityID);
-              }
-            }
-
-            return Promise.reject(new Error('No Identity Provider chosen, unable to retrieve data'));
-          });
-        } // The response body can only be read once, so return the clone
-
-
-        return clone;
-      });
-    }
-
-    return response;
-  });
 }
 
 _defineProperty(SessionManager, "json", function (response) {
@@ -976,7 +1082,7 @@ _defineProperty(SessionManager, "parseLocationId", function (response) {
 
   return Promise.reject(response);
 });
-},{"./keyManager.js":3}],9:[function(require,module,exports){
+},{"./keyManager.js":3,"./sessionContext.js":8}],10:[function(require,module,exports){
 "use strict";
 
 function _typeof(obj) { "@babel/helpers - typeof"; return _typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function (obj) { return typeof obj; } : function (obj) { return obj && "function" == typeof Symbol && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; }, _typeof(obj); }
@@ -1031,7 +1137,7 @@ var SinglefileContext = /*#__PURE__*/function (_AbstractProjectConte) {
 }(_abstractProjectContext.AbstractProjectContext);
 
 exports.SinglefileContext = SinglefileContext;
-},{"./abstractProjectContext.js":2,"./sessionManager.js":8}],10:[function(require,module,exports){
+},{"./abstractProjectContext.js":2,"./sessionManager.js":9}],11:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1095,7 +1201,7 @@ function TraceContext(sessionManager, collectionId, traceUid) {
 );
 
 exports.TraceContext = TraceContext;
-},{"./traceUid.js":12}],11:[function(require,module,exports){
+},{"./traceUid.js":13}],12:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -1250,7 +1356,7 @@ function TraceModelContext(sessionManager, projectId) {
 );
 
 exports.TraceModelContext = TraceModelContext;
-},{"./sessionManager.js":8}],12:[function(require,module,exports){
+},{"./sessionManager.js":9}],13:[function(require,module,exports){
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {

--- a/examples/app.js
+++ b/examples/app.js
@@ -57,6 +57,13 @@ app.post('/gatekeeper/projects/de554b81-e4a3-4759-96ec-0abf942be72c/traces/searc
     response.json(searchResult);
 });
 
+app.get('/gatekeeper/session/whoami', (request, response) => {
+    response.json(require('./mocks/whoami.json'));
+});
+
+app.get('/keystore/session/whoami', (request, response) => {
+    response.json(require('./mocks/whoami.json'));
+});
 
 app.listen(port, () => {
     console.log(`Example server started at http://localhost:${port}`);

--- a/examples/mocks/whoami.json
+++ b/examples/mocks/whoami.json
@@ -1,0 +1,6 @@
+{
+	"fquid": "https://user@keycloak.dev.local/auth/realms/idp",
+	"id": "user",
+	"name": "User 1",
+	"uid": "user@keycloak.dev.local"
+}

--- a/examples/session.html
+++ b/examples/session.html
@@ -1,0 +1,14 @@
+<script type="text/javascript" src="./node_modules/lodash/lodash.min.js"></script>
+<script type="module">
+    import {HanskenClient} from './src/hansken-js.js';
+
+    const hansken = new HanskenClient('/gatekeeper', '/keystore');
+
+    hansken.session('gatekeeper').whoami().then((whoami) => {
+        document.write('<pre>' + JSON.stringify(whoami, null, 2) + '<pre>');
+
+        hansken.session('gatekeeper').whoami().then((whoami) => {
+            document.write('<pre>' + JSON.stringify(whoami, null, 2) + '<pre>');
+        });
+    });
+</script>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
     "description": "The Hansken Javascript API",
     "main": "src/hansken.js",
     "license": "Apache-2.0",
-    "type": "module",
     "keywords": [
         "Hansken"
     ],

--- a/src/hansken-js.js
+++ b/src/hansken-js.js
@@ -72,6 +72,14 @@ class HanskenClient {
     keyManager = () => this.sessionManager.keyManager();
 
     /**
+     * Create a session context for a specific service. (gatekeeper or keystore).
+     *
+     * @param {'gatekeeper' | ' keystore'} serviceName The name of the service
+     * @returns A SessionContext for the service
+     */
+    session = (serviceName) => this.sessionManager.session(serviceName);
+
+    /**
      * Get a context for a single file, to do project specific REST calls.
      *
      * @param {UUID} singlefileId The single file id

--- a/src/modules/keyManager.js
+++ b/src/modules/keyManager.js
@@ -11,6 +11,7 @@ class KeyManager {
      */
     constructor(sessionManager) {
         this.sessionManager = sessionManager;
+        this.sessionContext = this.sessionManager.session('keystore');
     }
 
     /**
@@ -24,8 +25,7 @@ class KeyManager {
             // Return key from cache
             return Promise.resolve(this.#cache[imageId]);
         }
-        return this.sessionManager.keystore('/session/whoami')
-            .then(SessionManager.json)
+        return this.sessionContext.whoami()
             .then((whoami) => this.sessionManager.keystore(`/entries/${imageId}/${whoami.uid}`, {
                 method: 'GET'
             }))

--- a/src/modules/sessionContext.js
+++ b/src/modules/sessionContext.js
@@ -1,0 +1,30 @@
+import { SessionManager } from './sessionManager.js';
+
+class SessionContext {
+    #whoami;
+
+    /**
+     * Create a context for the session of a hansken service.
+     *
+     * @param {SessionManager} sessionManager The session manager, used for connections to the Hansken servers
+     * @param {string} The url of the hansken service
+     */
+    constructor(sessionManager, serviceUrl) {
+        this.sessionManager = sessionManager;
+        this.serviceUrl = serviceUrl;
+    }
+
+    whoami = () => {
+        if (this.#whoami) {
+            return Promise.resolve(this.#whoami);
+        }
+        return this.sessionManager.fetch(this.serviceUrl, '/session/whoami')
+        .then(SessionManager.json)
+        .then((whoami) => {
+            this.#whoami = whoami;
+            return whoami;
+        });
+    };
+}
+
+export { SessionContext };


### PR DESCRIPTION
So we can invoke `whoami()` in the keystore and keep it in cache