### PR TITLE
Added "search after" way to stream traces in batches

### DIFF
--- a/examples/search-after.html
+++ b/examples/search-after.html
@@ -1,0 +1,17 @@
+<script type="text/javascript" src="./node_modules/lodash/lodash.min.js"></script>
+<script type="module">
+    import {HanskenClient} from './src/hansken-js.js';
+
+    // Note: no mocks available for this example
+    const hansken = new HanskenClient('/gatekeeper', '/keystore');
+    const request = {
+        query: {
+            human: 'type:email'
+        },
+        count: 1000
+    };
+
+    hansken.project('de554b81-e4a3-4759-96ec-0abf942be72c').search().tracesAfter(request, (result) => {
+        document.write(result.trace.uid + '<br>');
+    });
+</script>


### PR DESCRIPTION
Added a new way to stream traces, by using the elastic search "search after" feature. This way, all traces for a search request can be iterated.